### PR TITLE
Add banner to legacy versions

### DIFF
--- a/0.12/bitcoin.html
+++ b/0.12/bitcoin.html
@@ -364,6 +364,9 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <script>hljs.initHighlightingOnLoad()</script>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill and Bitcoin</h1>
 <span id="author" class="author">Kill Bill core team &lt;killbilling-users@googlegroups.com&gt;</span><br>

--- a/0.12/faq.html
+++ b/0.12/faq.html
@@ -364,6 +364,9 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <script>hljs.initHighlightingOnLoad()</script>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill FAQ</h1>
 <span id="author" class="author">Kill Bill core team &lt;killbilling-users@googlegroups.com&gt;</span><br>

--- a/0.12/payments.html
+++ b/0.12/payments.html
@@ -364,6 +364,9 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <script>hljs.initHighlightingOnLoad()</script>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill payment guide</h1>
 <span id="author" class="author">Kill Bill core team &lt;killbilling-users@googlegroups.com&gt;</span><br>

--- a/0.12/userguide.html
+++ b/0.12/userguide.html
@@ -364,6 +364,9 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <script>hljs.initHighlightingOnLoad()</script>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill user guide</h1>
 <span id="author" class="author">Kill Bill core team &lt;killbilling-users@googlegroups.com&gt;</span><br>

--- a/0.14/aws.html
+++ b/0.14/aws.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill AWS Deployment</h1>
 <div id="toc" class="toc">

--- a/0.14/bitcoin.html
+++ b/0.14/bitcoin.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill and Bitcoin</h1>
 <div id="toc" class="toc">

--- a/0.14/consumable_in_arrear.html
+++ b/0.14/consumable_in_arrear.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Usage: consumable in arrear</h1>
 <div id="toc" class="toc">

--- a/0.14/multi_gateways.html
+++ b/0.14/multi_gateways.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill tutorial</h1>
 <div id="toc" class="toc">

--- a/0.14/multi_tenancy.html
+++ b/0.14/multi_tenancy.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Multi-tenancy</h1>
 <div id="toc" class="toc">

--- a/0.14/overdue.html
+++ b/0.14/overdue.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Overdue System</h1>
 <div id="toc" class="toc">

--- a/0.14/userguide_analytics.html
+++ b/0.14/userguide_analytics.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill analytics guide</h1>
 <div id="toc" class="toc">

--- a/0.14/userguide_kaui.html
+++ b/0.14/userguide_kaui.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill Administrative UI</h1>
 <div id="toc" class="toc">

--- a/0.14/userguide_payment.html
+++ b/0.14/userguide_payment.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill payment guide</h1>
 <div id="toc" class="toc">

--- a/0.14/userguide_platform.html
+++ b/0.14/userguide_platform.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill platform guide</h1>
 <div id="toc" class="toc">

--- a/0.14/userguide_subscription.html
+++ b/0.14/userguide_subscription.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill subscription guide</h1>
 <div id="toc" class="toc">

--- a/0.15/aws.html
+++ b/0.15/aws.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill AWS Deployment</h1>
 <div id="toc" class="toc">

--- a/0.15/bitcoin.html
+++ b/0.15/bitcoin.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill and Bitcoin</h1>
 <div id="toc" class="toc">

--- a/0.15/consumable_in_arrear.html
+++ b/0.15/consumable_in_arrear.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Usage: consumable in arrear</h1>
 <div id="toc" class="toc">

--- a/0.15/faq.html
+++ b/0.15/faq.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>FAQ</h1>
 <div id="toc" class="toc">

--- a/0.15/getting_started.html
+++ b/0.15/getting_started.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Getting started</h1>
 <div id="toc" class="toc">

--- a/0.15/internationalization.html
+++ b/0.15/internationalization.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Internationalization Overview</h1>
 <div id="toc" class="toc">

--- a/0.15/multi_gateways.html
+++ b/0.15/multi_gateways.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill tutorial</h1>
 <div id="toc" class="toc">

--- a/0.15/multi_tenancy.html
+++ b/0.15/multi_tenancy.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Multi-tenancy</h1>
 <div id="toc" class="toc">

--- a/0.15/overdue.html
+++ b/0.15/overdue.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Overdue System</h1>
 <div id="toc" class="toc">

--- a/0.15/payment_plugin.html
+++ b/0.15/payment_plugin.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Developing a Payment Plugin</h1>
 <div id="toc" class="toc">

--- a/0.15/plugin_management.html
+++ b/0.15/plugin_management.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Plugin Management APIs</h1>
 <div id="toc" class="toc">

--- a/0.15/user_management.html
+++ b/0.15/user_management.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Overview</h1>
 <div id="toc" class="toc">

--- a/0.15/userguide_analytics.html
+++ b/0.15/userguide_analytics.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill analytics guide</h1>
 <div id="toc" class="toc">

--- a/0.15/userguide_configuration.html
+++ b/0.15/userguide_configuration.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill configuration guide</h1>
 <div id="toc" class="toc">

--- a/0.15/userguide_deployment.html
+++ b/0.15/userguide_deployment.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill deployment guide</h1>
 <div id="toc" class="toc">

--- a/0.15/userguide_kaui.html
+++ b/0.15/userguide_kaui.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill Administrative UI</h1>
 <div id="toc" class="toc">

--- a/0.15/userguide_payment.html
+++ b/0.15/userguide_payment.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill payment guide</h1>
 <div id="toc" class="toc">

--- a/0.15/userguide_platform.html
+++ b/0.15/userguide_platform.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill platform guide</h1>
 <div id="toc" class="toc">

--- a/0.15/userguide_subscription.html
+++ b/0.15/userguide_subscription.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill subscription guide</h1>
 <div id="toc" class="toc">

--- a/0.16/aws.html
+++ b/0.16/aws.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill AWS Deployment</h1>
 <div id="toc" class="toc">

--- a/0.16/bitcoin.html
+++ b/0.16/bitcoin.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill and Bitcoin</h1>
 <div id="toc" class="toc">

--- a/0.16/catalog_plugin.html
+++ b/0.16/catalog_plugin.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Developing a Catalog Plugin</h1>
 <div id="toc" class="toc">

--- a/0.16/consumable_in_arrear.html
+++ b/0.16/consumable_in_arrear.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Usage: consumable in arrear</h1>
 <div id="toc" class="toc">

--- a/0.16/database_migrations.html
+++ b/0.16/database_migrations.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill Database Migrations</h1>
 <div id="toc" class="toc">

--- a/0.16/faq.html
+++ b/0.16/faq.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>FAQ</h1>
 <div id="toc" class="toc">

--- a/0.16/getting_started.html
+++ b/0.16/getting_started.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Getting started</h1>
 <div id="toc" class="toc">

--- a/0.16/ha.html
+++ b/0.16/ha.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Hierarchical Accounts Tutorial</h1>
 <div id="toc" class="toc">

--- a/0.16/internationalization.html
+++ b/0.16/internationalization.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Internationalization Overview</h1>
 <div id="toc" class="toc">

--- a/0.16/invoice_plugin.html
+++ b/0.16/invoice_plugin.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Developing an Invoice Control Plugin</h1>
 <div id="toc" class="toc">

--- a/0.16/migration_guide.html
+++ b/0.16/migration_guide.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill Migration Guide</h1>
 <div id="toc" class="toc">

--- a/0.16/multi_gateways.html
+++ b/0.16/multi_gateways.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Step-by-step integration with Stripe and PayPal</h1>
 <div id="toc" class="toc">

--- a/0.16/multi_tenancy.html
+++ b/0.16/multi_tenancy.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Multi-tenancy</h1>
 <div id="toc" class="toc">

--- a/0.16/overdue.html
+++ b/0.16/overdue.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Overdue System</h1>
 <div id="toc" class="toc">

--- a/0.16/payment_control_plugin.html
+++ b/0.16/payment_control_plugin.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Developing a Payment Control Plugin</h1>
 <div id="toc" class="toc">

--- a/0.16/payment_plugin.html
+++ b/0.16/payment_plugin.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Developing a Payment Plugin</h1>
 <div id="toc" class="toc">

--- a/0.16/plugin_development.html
+++ b/0.16/plugin_development.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Plugin development</h1>
 <div id="toc" class="toc">

--- a/0.16/plugin_management.html
+++ b/0.16/plugin_management.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Plugin Management APIs</h1>
 <div id="toc" class="toc">

--- a/0.16/user_management.html
+++ b/0.16/user_management.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Overview</h1>
 <div id="toc" class="toc">

--- a/0.16/userguide_analytics.html
+++ b/0.16/userguide_analytics.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill analytics guide</h1>
 <div id="toc" class="toc">

--- a/0.16/userguide_configuration.html
+++ b/0.16/userguide_configuration.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill configuration guide</h1>
 <div id="toc" class="toc">

--- a/0.16/userguide_deployment.html
+++ b/0.16/userguide_deployment.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill deployment guide</h1>
 <div id="toc" class="toc">

--- a/0.16/userguide_kaui.html
+++ b/0.16/userguide_kaui.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill Administrative UI</h1>
 <div id="toc" class="toc">

--- a/0.16/userguide_payment.html
+++ b/0.16/userguide_payment.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill payment guide</h1>
 <div id="toc" class="toc">

--- a/0.16/userguide_platform.html
+++ b/0.16/userguide_platform.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill platform guide</h1>
 <div id="toc" class="toc">

--- a/0.16/userguide_subscription.html
+++ b/0.16/userguide_subscription.html
@@ -475,6 +475,9 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </style>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill subscription guide</h1>
 <div id="toc" class="toc">

--- a/0.8/userguide.html
+++ b/0.8/userguide.html
@@ -364,6 +364,9 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <script>hljs.initHighlightingOnLoad()</script>
 </head>
 <body class="book">
+<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;">
+<strong>This version of Kill Bill is not supported anymore, please see our <a href="https://docs.killbill.io">latest documentation</a></strong>
+</div>
 <div id="header">
 <h1>Kill Bill user guide</h1>
 <span id="author" class="author">Kill Bill core team &lt;killbilling-users@googlegroups.com&gt;</span><br>

--- a/deprecate_version.sh
+++ b/deprecate_version.sh
@@ -1,0 +1,10 @@
+if [ "$#" -ne 1 ]
+then
+  echo "Usage: $0 version"
+  exit 1
+fi
+
+sed -i '' 's|\<body class="book"\>|\<body class="book"\>\
+\<div style="background-color: hsl(353, 100%, 95%); color: #ff0000; position: sticky; top: 0; padding-top: 20px; padding-bottom: 20px; text-align: center; z-index: 10;"\>\
+\<strong\>This version of Kill Bill is not supported anymore, please see our \<a href="https://docs.killbill.io"\>latest documentation\</a\>\</strong\>\
+\</div\>|' ./$1/*.html


### PR DESCRIPTION
The 0.14 documentation is still heavily referenced on the mailing-list. Add a banner to point folks to the latest version.


![image](https://user-images.githubusercontent.com/51940/39911653-02d8af26-54b1-11e8-91fe-c5af3fb2461c.png)

It is sticky as you scroll:

![image](https://user-images.githubusercontent.com/51940/39911643-fc300d90-54b0-11e8-8fac-a57ef1408e5d.png)
