### PR TITLE
Version 0.20 of killbell seems to require more than 2GB mem in order …

### DIFF
--- a/userguide/tutorials/getting_started.adoc
+++ b/userguide/tutorials/getting_started.adoc
@@ -103,7 +103,7 @@ The next step is to create a Docker machine to run your containers:
 
 [source,bash]
 ----
-docker-machine create -d virtualbox --virtualbox-memory "2048" killbill
+docker-machine create -d virtualbox --virtualbox-memory "4096" killbill
 eval $(docker-machine env killbill)
 ----
 


### PR DESCRIPTION
…to start up properly