### PR TITLE
debugging: fix legacy config name for Shiro iterations

### DIFF
--- a/userguide/tutorials/debugging.adoc
+++ b/userguide/tutorials/debugging.adoc
@@ -284,7 +284,7 @@ echo 1 > /proc/sys/net/ipv4/tcp_tw_reuse
 * On the server side, check the expected concurrency level by watching the number of sockets in `ESTABLISHED` (`watch 'netstat -an | grep 8080 | grep EST | wc -l'`)
 * Make sure to allocate enough database (`org.killbill.dao.maxActive` / `org.killbill.billing.osgi.dao.maxActive`) and plugin (`org.killbill.payment.plugin.threads.nb`) threads. Check your container thread pool too (e.g. `conf/server.xml` for Tomcat)
 * Use tools like Siege (http://www.joedog.org/siege-home/) to verify your basic setup: `siege -b -t30S -c100 http://127.0.0.1:8080/1.0/kb/test/clock` should yield at least 5k req./s.
-* If Shiro is spending too many CPU cycles for authentication, lower the default number of iterations (e.g. `org.killbill.server.multitenant.hash_iterations=2000`).
+* If Shiro is spending too many CPU cycles for authentication, lower the default number of iterations (e.g. `org.killbill.security.shiroNbHashIterations=2000`).
 * When using YourKit, turn off probes (especially the database ones). They cause a significant slowdown.
 * Allow a warm-up period, before starting a full test, to avoid contention in the JRuby JIT.
 * Use https://github.com/AdoptOpenJDK/mjprof[mjprof] to extract stacktraces:


### PR DESCRIPTION
This was changed here: https://github.com/killbill/killbill/commit/3a0902b0c865ee9d9be4034308665bb37839a229

/cc @brunner