### PR TITLE
Fix getting_started titles

### DIFF
--- a/userguide/tutorials/getting_started.adoc
+++ b/userguide/tutorials/getting_started.adoc
@@ -1,4 +1,4 @@
-= Getting started
+= Getting Started
 
 == Introduction
 
@@ -25,7 +25,7 @@ Check this video for a quick tour:
 
 https://www.youtube.com/watch?v=f2IHcz3OLYo[image:http://img.youtube.com/vi/f2IHcz3OLYo/0.jpg[align=center]]
 
-=== The Kill Bill platform
+=== The Kill Bill Platform
 
 Some of the features of the Kill Bill platform include:
 
@@ -51,9 +51,9 @@ Kill Bill is packaged as a WAR and is therefore executed within a web container 
 
 Kill Bill supports multi-tenancy, meaning you can run multiple logical instances of Kill Bill with a single server and database (see this http://killbill.io/blog/subscription-service-using-kill-bill[blog post] which illustrates some of the use cases).
 
-=== Where To Start?
+=== Where to Start?
 
-==== Layman's next steps
+==== Layman's Next Steps
 
 If you are interested to know more about what Kill Bill is about, the following links will be of interest:
 
@@ -62,7 +62,7 @@ If you are interested to know more about what Kill Bill is about, the following 
 * http://killbill.io/blog/[Our official blog]
 * https://www.capterra.com/p/159213/Kill-Bill/#reviews[User reviews on Capterra, a Gartner company]
 
-==== Technical guides
+==== Technical Guides
 
 To start integrating Kill Bill in your environment:
 
@@ -189,7 +189,7 @@ Go to http://192.168.99.100:9090[http://192.168.99.100:9090] (update the IP addr
 
 Because Kill Bill supports multi-tenancy (where each tenant has its own data, configuration, etc.), the next step is to create your own tenant. We will assume the api key is `bob` and api secret `lazar` in the rest of this guide.
 
-=== Modifying the catalog
+=== Modifying the Catalog
 
 The Kill Bill *catalog* contains products and plans definitions. This XML configuration file is really powerful and offers various options for handling trials, add-ons, upgrades/downgrades, etc. For more details on its features, read the http://docs.killbill.io/latest/userguide_subscription.html[Subscription Billing manual].
 
@@ -203,7 +203,7 @@ image:https://github.com/killbill/killbill-docs/raw/v3/userguide/assets/img/tuto
 image:https://github.com/killbill/killbill-docs/raw/v3/userguide/assets/img/tutorials/multi_gateways_standard-monthly_kaui.png[align=center]
 image:https://github.com/killbill/killbill-docs/raw/v3/userguide/assets/img/tutorials/multi_gateways_catalog_kaui.png[align=center]
 
-=== Creating your first account
+=== Creating Your First Account
 
 We will assume that users going to your site have to create an account in your system. When they do, you will need to create a mirrored *account* in Kill Bill.
 
@@ -214,7 +214,7 @@ Notes:
 * The Kill Bill *External key* field should map to the unique id of the account in your system (should be unique and immutable). Kill Bill will auto-generate an id if you don't populate this field
 * There are many more fields you can store (phone number, address, etc.) -- all of them are optional. Keep local regulations in mind though when populating these (PII laws, GDPR, etc.).
 
-=== Adding a payment method
+=== Adding a Payment Method
 
 To trigger payments, Kill Bill will need to integrate with a payment provider (such as Stripe or PayPal). Each means of payment (e.g. a credit card) will have a *payment method* associated with it.
 
@@ -222,7 +222,7 @@ For simplicity in this tutorial, we will assume your customers send you checks. 
 
 Once you are ready to integrate with a real payment processor (see http://docs.killbill.io/latest/multi_gateways.html[this tutorial]), all you'll have to do is to create a new payment method for that account. The rest of this tutorial will still apply.
 
-=== Creating your first subscription
+=== Creating Your First Subscription
 
 Let's now try to subscribe a user to the Standard plan. This is the call that would need to be triggered from your website, when the user chooses the premium plan on the subscription checkout page.
 
@@ -234,7 +234,7 @@ You should see the invoice and the payment by clicking on the Invoices and Payme
 
 Kill Bill will now automatically charge the user on a monthly basis. You can estimate the amount which will be billed at a future date by triggering a dry-run invoice. On the main account page, in the Billing Info section, click the *Trigger invoice generation* wand (specify a date at least a month in the future).
 
-== Using Kill Bill from your application
+== Using Kill Bill from Your Application
 
 Now that you are familiar with the basics, the next step is to integrate Kill Bill in your application using our APIs. Our https://killbill.github.io/slate/[API documentation] contains snippets to help you get started.
 


### PR DESCRIPTION
This PR is to fix the getting_started page titles. Titles' words should be in uppercase.
