### PR TITLE
Added a section that points to the debugging document

### DIFF
--- a/userguide/tutorials/debugging.adoc
+++ b/userguide/tutorials/debugging.adoc
@@ -525,7 +525,7 @@ In your message, specify:
 
 * What you are seeing and what you are expecting
 * How to reproduce your scenario (cURL commands, code snippet, ...)
-* https://github.com/killbill/killbill-cloud[KPM] diagnostic output, e.g.
+* https://github.com/killbill/killbill-cloud/tree/9305e1abb8840f22a03d2c36269710bff3dc1996/kpm[KPM] diagnostic output, e.g.
 
 [source,bash]
 ----

--- a/userguide/tutorials/development.adoc
+++ b/userguide/tutorials/development.adoc
@@ -441,6 +441,10 @@ Sometimes, you may face some issues in running the application. In such cases, i
 
 . This runs the application in debug mode. You can also set additional breakpoints as required.
 
+=== Further Debugging 
+
+The https://docs.killbill.io/latest/debugging.html[Debugging Tips] document includes some additional debugging tips for Kill Bill in general. You may also reach out to the Kill Bill https://groups.google.com/forum/#!forum/killbilling-users[mailing list], with the `kpm diagnostic` output as explained in the https://docs.killbill.io/latest/debugging.html#_seeking_help[Seeking Help] section.
+
 
 === Some common errors and their solutions
 

--- a/userguide/tutorials/getting_started.adoc
+++ b/userguide/tutorials/getting_started.adoc
@@ -518,7 +518,9 @@ We recommend installing the *Apache Tomcat Native Library*. In order to do this,
 
 If you are unable to install the Tomcat Native Library on Windows, you may skip this step.
 
+==== Further Debugging 
 
+The https://docs.killbill.io/latest/debugging.html[Debugging Tips] document includes some additional debugging tips for Kill Bill in general. You may also reach out to the Kill Bill https://groups.google.com/forum/#!forum/killbilling-users[mailing list], with the `kpm diagnostic` output as explained in the https://docs.killbill.io/latest/debugging.html#_seeking_help[Seeking Help] section.
 
 ==== FAQ
 

--- a/userguide/tutorials/plugin_development.adoc
+++ b/userguide/tutorials/plugin_development.adoc
@@ -189,6 +189,10 @@ When you start developing your own plugin, it would be useful to be able to set 
 
 . This runs the application in debug mode. You can also set additional breakpoints as required.
 
+=== Further Debugging 
+
+The https://docs.killbill.io/latest/debugging.html[Debugging Tips] document includes some additional debugging tips for Kill Bill in general. You may also reach out to the Kill Bill https://groups.google.com/forum/#!forum/killbilling-users[mailing list], with the `kpm diagnostic` output as explained in the https://docs.killbill.io/latest/debugging.html#_seeking_help[Seeking Help] section.
+
 
 === Additional Configuration
 

--- a/userguide/tutorials/stripe_plugin.adoc
+++ b/userguide/tutorials/stripe_plugin.adoc
@@ -163,7 +163,7 @@ Next, run the stripe demo application using your Stripe publishable key as follo
 ----
 PUBLISHABLE_KEY=pk_test_XXX ruby app.rb
 ----
-==== Step 8: Test the demo application
+=== Step 8: Test the demo application
 
 In your browser, navigate to \http://localhost:4567/. This displays the following screen:
 
@@ -173,7 +173,7 @@ Enter dummy data (4242 4242 4242 4242 as the credit card number, any three digit
 
 image:https://github.com/killbill/killbill-docs/raw/v3/userguide/assets/img/tutorials/stripe_integration_confirmation_page.png[align=center]
 
-==== Step 9:  What just happened?
+=== Step 9:  What just happened?
 
 After we complete the checkout process with Stripe, the card has been tokenized, or intercepted and replaced with a surrogate token ID.  If you visit to the Stripe Dashboard (https://dashboard.stripe.com), you should be able to navigate to the Payments page in the left-hand panel to see a succeeded Kill Bill charge for $10.
 


### PR DESCRIPTION
- Updated Development, Getting Started, and Plugin Development document with a section that points to the debugging document
- Fixed headings in the Stripe plugin document
- Updated kpm link in the debugging document