### PR TITLE
Updated syntax highlighting to `properties` 

### DIFF
--- a/userguide/tutorials/overdue.adoc
+++ b/userguide/tutorials/overdue.adoc
@@ -224,7 +224,7 @@ In more detail:
 ==== Uploading overdue configuration
 
 This XML file can be specified as a property in the Kill Bill configuration file as follows:
-[source,bash]
+[source,properties]
 ----
 org.killbill.overdue.uri=file:///<path>/overdue.xml
 ----
@@ -251,7 +251,7 @@ The scenario defined above also requires the payments to be attempted 4 times wi
 
 
 The payment retry schedule can be configured as a property in the Kill Bill configuration file as follows:
-[source,bash]
+[source,properties]
 ----
 org.killbill.payment.retry.days=1,8,4,7
 ----


### PR DESCRIPTION
Updated syntax highlighting to `properties` for the `org.killbill.overdue.uri` and `org.killbill.payment.retry.days` examples