### PR TITLE
Added additional docs to left nav

### DIFF
--- a/html5/_main_toc.html.slim
+++ b/html5/_main_toc.html.slim
@@ -51,6 +51,9 @@ nav.sidebar-nav
         </svg>
       ul.nav.navbar-nav
         li.bd-sidenav-active
+          a.nav-link href="/latest/aws.html"
+            | AWS Introduction
+        li
           a.nav-link href="/latest/how-to-set-up-a-single-tier-system.html"
             | Single-Tier Setup
         li
@@ -59,7 +62,10 @@ nav.sidebar-nav
         li
           a.nav-link href="/latest/how-to-set-up-a-cloud-formation-system.html"
             | CloudFormation Setup
-        li.bd-sidenav-active
+        li
+          a.nav-link href="/latest/aws-container.html"
+            | AWS Container Setup
+        li
           a.nav-link href="/latest/how-to-maintain-a-single-tier-system.html"
             | Single-Tier Maintenance
         li
@@ -68,6 +74,33 @@ nav.sidebar-nav
         li
           a.nav-link href="/latest/how-to-maintain-a-cloud-formation-system.html"
             | CloudFormation Maintenance
+        li
+          a.nav-link href="/latest/explanation-https-and-certificates.html"
+            | HTTPS and Certificates
+        li
+          a.nav-link href="/latest/how-to-add-a-certificate-using-ACM.html"
+            | How to add a certificate using ACM
+        li
+          a.nav-link href="/latest/using-ses-with-aws.html"
+            | Using SES with AWS
+        li
+          a.nav-link href="/latest/aws-tools.html"
+            | AWS Observability Tools
+        li
+          a.nav-link href="/latest/metrics-datadog.html"
+            | Managing Metrics with Datadog
+        li
+          a.nav-link href="/latest/metrics-newrelic.html"
+            | Managing Metrics with New Relic
+        li
+          a.nav-link href="/latest/metrics-cloudwatch.html"
+            | Managing Metrics with Cloudwatch
+        li
+          a.nav-link href="/latest/errors-rollbar.html"
+            | Error Tracking with Rollbar
+        li
+          a.nav-link href="/latest/errors-sentry.html"
+            | Error Tracking with Sentry
     li
       .icon-title
         a.bd-toc-link.main-link role="button" Manuals
@@ -216,9 +249,6 @@ nav.sidebar-nav
         li
           a.nav-link href="/latest/plugin_management.html"
             | Plugin Management
-        li
-          a.nav-link href="/latest/aws-tools.html"
-            | AWS Analytics Tools
 
     li
       .icon-title


### PR DESCRIPTION
Added the following additional docs to the left nav bar under the `AWS` menu:

- aws.html
- aws-container.html
- explanation-https-and-certificates.html
- how-to-add-a-certificate-using-ACM.html
- using-ses-with-aws.html
- aws-tools.html (Moved this from `Operational Guides` section and renamed the title to `AWS Observability Tools`
- errors-rollbar.html
- errors-sentry.html 
- metrics-cloudwatch.html
- metrics-datadog.html
- metrics-newrelic.html

So now, the only doc missing from the left nav bar is `tutorial-single-tier.html`. I did not add this as we have a how-to doc for this topic: `how-to-set-up-a-single-tier-system.html`. As and when we add more tutorials for other documents and clearly distinguish tutorials from how-tos, we can consider adding this in, right now, I thought it might be confusing for users to have two docs with similar content.