### PR TITLE
Minor corrections

### DIFF
--- a/html5/_main_toc.html.slim
+++ b/html5/_main_toc.html.slim
@@ -355,7 +355,7 @@ nav.sidebar-nav
                 | Aviate Changelog
             li.bd-sidenav-active
               a.nav-link href="/latest/aviate-getting-started.html"
-                | Getting Started With Aviate
+                | Getting Started
             li.bd-sidenav-active
               a.nav-link href="/latest/aviate-catalog-guide.html"
                 | Aviate Catalog Guide

--- a/userguide/aviate/aviate-getting-started.adoc
+++ b/userguide/aviate/aviate-getting-started.adoc
@@ -4,8 +4,8 @@
 
 In this guide, you will:
 
-* Use *Aviate* to configure your billing environment.
-* Switch to *Kaui* to create your first customer and subscription.
+* Use http://aviate.killbill.io[*Aviate*] to configure your billing environment.
+* Switch to http://demo.killbill.io[*Kaui*] to create your first customer and subscription.
 * Generate and view an invoice.
 * Understand the role of *Kill Bill*, *Aviate*, and *Kaui*.
 * End up with a fully working fictive SaaS company set up for demos.
@@ -18,9 +18,9 @@ The example company used throughout this guide is *CloudSprout*, a fictional Saa
 
 Before starting, it helps to understand how the pieces fit together.
 
-* *Kill Bill* is the billing engine. It manages accounts, subscriptions, invoices, payments, and taxes.
-* *Aviate* is the Enterprise control and management plane. You use it to configure catalogs, taxes, invoice templates, and tenant settings, as well as proactively monitor the health of the billing engine.
-* *Kaui* is the billing operations UI. You use it for day-to-day actions such as creating customers, managing subscriptions, and reviewing invoices.
+* https://killbill.io/[*Kill Bill*] is the billing engine. It manages accounts, subscriptions, invoices, payments, and taxes.
+* http://aviate.killbill.io[*Aviate*] is the Enterprise control and management plane. You use it to configure catalogs, taxes, invoice templates, and tenant settings, as well as proactively monitor the health of the billing engine.
+* http://demo.killbill.io[*Kaui*] is the billing operations UI. You use it for day-to-day actions such as creating customers, managing subscriptions, and reviewing invoices.
 
 In short:
 
@@ -37,7 +37,7 @@ This checklist guides you through the minimum required setup to bill customers.
 
 You should complete all steps in order.
 
-=== Configure company settings
+=== Configure Company Settings
 
 This step defines who you are as a business.
 
@@ -63,7 +63,7 @@ The following demo shows how you can configure the company settings via Aviate.
 
 ''''
 
-=== Configure the catalog
+=== Configure the Catalog
 
 The catalog defines what you sell.
 
@@ -72,16 +72,22 @@ For CloudSprout, create a simple catalog with:
 * A small number of subscription plans (for example Starter, Team, Business).
 * Optional add-ons (for example Extra Storage).
 
-| Plan        | GBP         | EUR         | Notes             |
-| ----------- | ----------- | ----------- | ----------------- |
-| 🌱 Starter  | £9 / month  | €10 / month | Monthly only      |
-| 🌿 Team     | £29 / month | €32 / month | Monthly or annual |
-| 🌳 Business | £79 / month | €89 / month | Annual only       |
+[cols="1,1,1,1", options="header"]
+|===
+| Plan        | GBP         | EUR         | Notes
 
-| Add-on           | GBP | EUR | Billing |
-| ---------------- | --- | --- | ------- |
-| Extra Storage    | £5  | €6  | Monthly |
-| Priority Support | £15 | €18 | Monthly |
+| 🌱 Starter  | £9 / month  | €10 / month | Monthly only
+| 🌿 Team     | £29 / month | €32 / month | Monthly or annual
+| 🌳 Business | £79 / month | €89 / month | Annual only
+|===
+
+[cols="1,1,1,1", options="header"]
+|===
+| Add-on           | GBP | EUR | Billing
+
+| Extra Storage    | £5  | €6  | Monthly
+| Priority Support | £15 | €18 | Monthly
+|===
 
 The following demo shows how you can create the `CloudSprout Starter` plan via Aviate.
 ++++
@@ -99,9 +105,11 @@ image::https://github.com/killbill/killbill-docs/raw/v3/userguide/assets/img/avi
 
 This step only defines products and plans. No customers are created yet.
 
+Refer to https://docs.killbill.io/latest/aviate-catalog-guide[Aviate Catalog Guide] for additional documentation.
+
 ''''
 
-=== Configure taxes
+=== Configure Taxes
 
 Taxes are configured in Aviate and applied automatically by Kill Bill.
 
@@ -124,6 +132,8 @@ The following demo explains how you can configure the above tax codes:
 </div>
 ++++
 
+Refer to https://docs.killbill.io/latest/aviate-tax[Aviate Tax] for additional documentation.
+
 ''''
 
 == Step 2: Switch to Kaui (Billing Operations)
@@ -144,7 +154,7 @@ The following demo illustrates how you can switch to Kaui:
 
 ''''
 
-=== Create your first customer
+=== Create Your First Customer
 
 In Kaui:
 
@@ -169,7 +179,7 @@ The following demo illustrates the account creation process in Kaui:
 
 At this point, you have a customer but no billing activity yet.
 
-=== Create a subscription
+=== Create a Subscription
 
 Next, attach a subscription to the customer.
 
@@ -194,7 +204,7 @@ The following demo guides you through the subscription creation process in Kaui:
 
 ''''
 
-=== View the invoice
+=== View The Invoice
 
 Once the subscription is active:
 


### PR DESCRIPTION
- Add more links to aviate.killbill.io
- Rename `Getting Started With Aviate` --> `Getting Started`
- Fix table in Getting started guide
- Other minor corrections