### PR TITLE
Reorganizing left nav bar

### DIFF
--- a/html5/_main_toc.html.slim
+++ b/html5/_main_toc.html.slim
@@ -41,9 +41,18 @@ nav.sidebar-nav
         li
           a.nav-link href="/latest/killbill-changelog.html"
             | Kill Bill Changelog
+         li
+           a.nav-link href="https://github.com/killbill/killbill/releases"
+             | Kill Bill Release Notes
+         li
+           a.nav-link href="https://github.com/killbill/killbill-admin-ui-standalone/releases"
+             | Kaui Release Notes
         li
           a.nav-link href="/latest/quick_start_with_kaui.html"
             | Quick Start with Kaui
+        li
+          a.nav-link href="/latest/userguide_kaui.html"
+            | Kaui User Guide
         li
           a.nav-link href="/latest/quick_start_with_kb_api.html"
             | Quick Start with the API
@@ -64,9 +73,6 @@ nav.sidebar-nav
         li
           a.nav-link href="/latest/userguide_payment.html"
             | Payment Processing
-        li
-          a.nav-link href="/latest/userguide_kaui.html"
-            | Kaui Admin UI
         li
           a.nav-link href="/latest/userguide_configuration.html"
             | Kill Bill Configuration
@@ -144,8 +150,8 @@ nav.sidebar-nav
           a.nav-link href="/latest/user_management.html"
             | Users, Roles & Permissions
         li
-          a.nav-link href="/latest/plugin_management.html"
-            | Plugin Management
+          a.nav-link href="/latest/how-to-use-kpm-diagnostic.html"
+            | KPM Diagnostic
     li
       .icon-title
         a.bd-toc-link.main-link role="button"
@@ -164,14 +170,14 @@ nav.sidebar-nav
           a.nav-link href="/latest/plugin_installation.html"
             | Plugin Installation
         li
+          a.nav-link href="/latest/plugin_management.html"
+            | Plugin Management
+        li
           a.nav-link href="/latest/plugin_use_cases.html"
             | Special Plugin Use Cases
         li
           a.nav-link href="/latest/email-notification-plugin.html"
             | Email Notification Plugin
-        li
-          a.nav-link href="/latest/custom-email-invoice-formatter.html"
-            | Custom Email Formatter
         li
           a.nav-link href="/latest/userguide_analytics.html"
             | Analytics Plugin
@@ -199,6 +205,9 @@ nav.sidebar-nav
         li
           a.nav-link href="/latest/entitlement_plugin.html"
             | Entitlement Plugins
+        li
+          a.nav-link href="/latest/custom-email-invoice-formatter.html"
+            | Custom Email Formatter
     li
       .icon-title
         a.bd-toc-link.main-link role="button"
@@ -388,9 +397,6 @@ nav.sidebar-nav
         </svg>
       ul.nav.navbar-nav
         li
-          a.nav-link href="/latest/how-to-use-kpm-diagnostic.html"
-            | KPM Diagnostic
-        li
           a.nav-link href="https://github.com/killbill/killbill-docs/tree/v3/swagger"
             | Swagger API Schema
         li
@@ -399,9 +405,6 @@ nav.sidebar-nav
         li
           a.nav-link href="/latest/overdue.xsd"
             | Overdue XSD
-        li
-          a.nav-link href="https://github.com/killbill/killbill/releases"
-            | Release Notes
     li
       .icon-title
         a.bd-toc-link.main-link role="button"


### PR DESCRIPTION
- Moved KB/Kaui Release Notes to Getting Started Section
- Moved Kaui User Guide to Getting Started Section
- Moved Plugin Management doc to Plugins section
- Moved KPM Diagnostic to Deploy and Operate section
- In the plugins section, grouped the documents as per type (ex. Plugin Manuals together, etc.)

