### PR TITLE
Documentation Changes

### DIFF
--- a/html5/_main_toc.html.slim
+++ b/html5/_main_toc.html.slim
@@ -319,6 +319,9 @@ nav.sidebar-nav
           a.nav-link href="/latest/aviate-changelog.html"
             | Aviate Changelog
         li
+          a.nav-link href="/latest/aviate-deployment-management.html"
+            | Deployment Management
+        li
           a.nav-link href="/latest/aviate-getting-started.html"
             | Getting Started
         li

--- a/userguide/aviate/aviate-catalog-guide.adoc
+++ b/userguide/aviate/aviate-catalog-guide.adoc
@@ -95,14 +95,9 @@ WARNING: Deleting a plan could break the system if there are active subscription
 
 Demo:
 
-++++
-<div>
-<script async src="https://js.storylane.io/js/v2/storylane.js"></script>
-<div class="sl-embed" style="position:relative;padding-bottom:calc(49.85% + 25px);width:100%;height:0;transform:scale(1)">
-<iframe loading="lazy" class="sl-demo" src="https://killbill.storylane.io/demo/2mzetbzl440n?embed=inline" name="sl-embed" allow="fullscreen" allowfullscreen style="position:absolute;top:0;left:0;width:100%!important;height:100%!important;border:1px solid rgba(63,95,172,0.35);box-shadow: 0px 0px 18px rgba(26, 19, 72, 0.15);border-radius:10px;box-sizing:border-box;"></iframe>
-</div>
-</div>
-++++
+:storylane-id: 2mzetbzl440n
+:storylane-embed-type: popup
+include::{sourcedir}/includes/storylane-embed.adoc[]
 
 API used: https://apidocs.killbill.io/aviate-catalog#delete-plan[Delete Plan API].
 
@@ -119,14 +114,9 @@ WARNING: Deleting a product could break the system if there are active subscript
 
 Demo:
 
-++++
-<div>
-  <script async src="https://js.storylane.io/js/v2/storylane.js"></script>
-  <div class="sl-embed" style="position:relative;padding-bottom:calc(49.85% + 25px);width:100%;height:0;transform:scale(1)">
-    <iframe loading="lazy" class="sl-demo" src="https://killbill.storylane.io/demo/ju6wzojzj4ib?embed=inline" name="sl-embed" allow="fullscreen" allowfullscreen style="position:absolute;top:0;left:0;width:100%!important;height:100%!important;border:1px solid rgba(63,95,172,0.35);box-shadow: 0px 0px 18px rgba(26, 19, 72, 0.15);border-radius:10px;box-sizing:border-box;"></iframe>
-  </div>
-</div>
-++++
+:storylane-id: ju6wzojzj4ib
+:storylane-embed-type: popup
+include::{sourcedir}/includes/storylane-embed.adoc[]
 
 == Duplicate Plan
 
@@ -158,15 +148,9 @@ You can create a new product based on an existing product. This is a time-saving
 
 Demo:
 
-++++
-<div>
-  <script async src="https://js.storylane.io/js/v2/storylane.js"></script>
-  <div class="sl-embed" style="position:relative;padding-bottom:calc(49.85% + 25px);width:100%;height:0;transform:scale(1)">
-    <iframe loading="lazy" class="sl-demo" src="https://killbill.storylane.io/demo/m2kja9avscji?embed=inline" name="sl-embed" allow="fullscreen" allowfullscreen style="position:absolute;top:0;left:0;width:100%!important;height:100%!important;border:1px solid rgba(63,95,172,0.35);box-shadow: 0px 0px 18px rgba(26, 19, 72, 0.15);border-radius:10px;box-sizing:border-box;"></iframe>
-  </div>
-</div>
-++++
-
+:storylane-id: m2kja9avscji
+:storylane-embed-type: inline
+include::{sourcedir}/includes/storylane-embed.adoc[]
 
 == Creating Usage Plans
 
@@ -186,9 +170,6 @@ include::{sourcedir}/includes/storylane-embed.adoc[]
 
 API used: https://apidocs.killbill.io/aviate-catalog#create-plan[Create Plan API].
 
-//TODO Delete Plan/Product
-
-//TODO Duplicate Plan/Product
 
 == Conclusion
 

--- a/userguide/aviate/aviate-deployment-management.adoc
+++ b/userguide/aviate/aviate-deployment-management.adoc
@@ -1,0 +1,59 @@
+= Aviate Deployment Management
+
+This guide explains how to add/manage a custom  Kill Bill deployment in the https://aviate.killbill.io[Aviate UI].
+
+== Prerequisites
+
+* Access to the https://aviate.killbill.io[Aviate UI] with a valid Flock account.
+* A running Kill Bill instance accessible from your network.
+* Administrative credentials for your Kill Bill instance (API key, API secret, and admin user credentials).
+
+== Add a Local Deployment
+
+You can add a local deployment to Aviate by providing the connection details (URL and credentials) for your Kill Bill instance. This allows you to manage your Kill Bill instance directly from the Aviate UI.
+
+Once a deployment is added, Aviate allows you to perform a wide range of management actions, including but not limited to:
+
+* Installing and managing plugins
+* Creating and managing product plans and catalogs
+* Configuring plugins and their properties
+* Uploading and managing invoice templates
+* Setting and updating tenant properties
+* Monitoring deployment status and plugin health
+
+Refer to the following demo for a walkthrough of the process to add a local deployment in Aviate:
+
+:storylane-id: uamhutfpgj7q
+:storylane-embed-type: inline
+include::{sourcedir}/includes/storylane-embed.adoc[]
+
+== Add a Tenant to an Existing Deployment
+
+You can also add a new tenant to an existing deployment. This allows you to manage multiple tenants within the same Kill Bill instance from Aviate.
+
+Refer to the following demo for a walkthrough of the process to add a tenant to an existing deployment in Aviate:
+
+:storylane-id: 83wimvrsbani
+:storylane-embed-type: inline
+include::{sourcedir}/includes/storylane-embed.adoc[]
+
+== Edit the Deployment
+
+You can edit the deployment details (e.g., URL, credentials, etc.) at any time from the Aviate UI. This is useful if you need to update the connection information or credentials for your Kill Bill instance.
+
+Refer to the following demo for a walkthrough of the process to edit a deployment in Aviate:
+
+:storylane-id: itb3ko5nt4lq
+:storylane-embed-type: inline
+include::{sourcedir}/includes/storylane-embed.adoc[]
+
+== Delete the Deployment
+
+You can delete a deployment from the Aviate UI if you no longer want to manage it through Aviate.
+
+Refer to the following demo for a walkthrough of the process to delete a deployment in Aviate:
+
+
+:storylane-id: zgsvpxse48pe
+:storylane-embed-type: inline
+include::{sourcedir}/includes/storylane-embed.adoc[]

--- a/userguide/aviate/aviate-getting-started.adoc
+++ b/userguide/aviate/aviate-getting-started.adoc
@@ -192,6 +192,7 @@ Once the subscription is active:
 This invoice uses the configuration, colors, and the logo defined earlier in Aviate.
 
 The following demo illustrates verifying the generated invoice:
+
 :storylane-id: 7t2szcxpfr27
 :storylane-embed-type: inline
 include::{sourcedir}/includes/storylane-embed.adoc[]

--- a/userguide/aviate/aviate-getting-started.adoc
+++ b/userguide/aviate/aviate-getting-started.adoc
@@ -130,6 +130,7 @@ After completing the Aviate checklist, the next steps happen in Kaui.
 From Aviate, use the *Billing Operations (Kaui)* links to open Kaui in a new tab.
 
 The following demo illustrates how you can switch to Kaui:
+
 :storylane-id: zb3tar3rqv1s
 :storylane-embed-type: popup
 include::{sourcedir}/includes/storylane-embed.adoc[]

--- a/userguide/aviate/aviate-getting-started.adoc
+++ b/userguide/aviate/aviate-getting-started.adoc
@@ -52,6 +52,7 @@ For the purpose of this guide, use the following fictive company:
 This information is later reused on invoices and customer communications.
 
 The following demo shows how you can configure the company settings via Aviate.
+
 :storylane-id: eykmjqwtc4vf
 :storylane-embed-type: popup
 include::{sourcedir}/includes/storylane-embed.adoc[]
@@ -85,6 +86,7 @@ For CloudSprout, create a simple catalog with:
 |===
 
 The following demo shows how you can create the `CloudSprout Starter` plan via Aviate.
+
 :storylane-id: ndzb6bp2lxvp
 :storylane-embed-type: inline
 include::{sourcedir}/includes/storylane-embed.adoc[]

--- a/userguide/tutorials/avatax-plugin.adoc
+++ b/userguide/tutorials/avatax-plugin.adoc
@@ -131,14 +131,9 @@ Alternatively, you can also configure these properties via the https://aviate.ki
 
 You can use the https://aviate.killbill.io/home[Aviate UI] to install/configure the plugin. Refer to the following demo:
 
-++++
-<div>
-  <script async src="https://js.storylane.io/js/v2/storylane.js"></script>
-  <div class="sl-embed" style="position:relative;padding-bottom:calc(49.85% + 25px);width:100%;height:0;transform:scale(1)">
-    <iframe loading="lazy" class="sl-demo" src="https://killbill.storylane.io/demo/y7yketvc81ih?embed=inline" name="sl-embed" allow="fullscreen" allowfullscreen style="position:absolute;top:0;left:0;width:100%!important;height:100%!important;border:1px solid rgba(63,95,172,0.35);box-shadow: 0px 0px 18px rgba(26, 19, 72, 0.15);border-radius:10px;box-sizing:border-box;"></iframe>
-  </div>
-</div>
-++++
+:storylane-id: y7yketvc81ih
+:storylane-embed-type: inline
+include::{sourcedir}/includes/storylane-embed.adoc[]
 
 == Kaui Integration
 
@@ -176,15 +171,9 @@ Refer to the following demo:
 
 NOTE: A demo is included for this section as tax calculation by zip code is the most common use case. For other features, follow the testing steps in each subsection.
 
-
-++++
-<div>
-  <script async src="https://js.storylane.io/js/v2/storylane.js"></script>
-  <div class="sl-embed" style="position:relative;padding-bottom:calc(49.85% + 25px);width:100%;height:0;transform:scale(1)">
-    <iframe loading="lazy" class="sl-demo" src="https://killbill.storylane.io/demo/ikqnmx0zqfe2?embed=inline" name="sl-embed" allow="fullscreen" allowfullscreen style="position:absolute;top:0;left:0;width:100%!important;height:100%!important;border:1px solid rgba(63,95,172,0.35);box-shadow: 0px 0px 18px rgba(26, 19, 72, 0.15);border-radius:10px;box-sizing:border-box;"></iframe>
-  </div>
-</div>
-++++
+:storylane-id: ikqnmx0zqfe2
+:storylane-embed-type: inline
+include::{sourcedir}/includes/storylane-embed.adoc[]
 
 === Tax Calculation by Product Tax Code
 

--- a/userguide/tutorials/braintree-plugin.adoc
+++ b/userguide/tutorials/braintree-plugin.adoc
@@ -76,15 +76,9 @@ Alternatively, you can also configure these properties via the https://aviate.ki
 
 You can use the https://aviate.killbill.io/home[Aviate UI] to install/configure the plugin. Refer to the following demo:
 
-++++
-<div>
-  <script async src="https://js.storylane.io/js/v2/storylane.js"></script>
-  <div class="sl-embed" style="position:relative;padding-bottom:calc(49.85% + 25px);width:100%;height:0;transform:scale(1)">
-    <iframe loading="lazy" class="sl-demo" src="https://killbill.storylane.io/demo/8hxhjuek5f2o?embed=inline" name="sl-embed" allow="fullscreen" allowfullscreen style="position:absolute;top:0;left:0;width:100%!important;height:100%!important;border:1px solid rgba(63,95,172,0.35);box-shadow: 0px 0px 18px rgba(26, 19, 72, 0.15);border-radius:10px;box-sizing:border-box;"></iframe>
-  </div>
-</div>
-++++
-
+:storylane-id: 8hxhjuek5f2o
+:storylane-embed-type: inline
+include::{sourcedir}/includes/storylane-embed.adoc[]
 
 [[testing_the_plugin]]
 == Testing the Plugin

--- a/userguide/tutorials/plugin_installation.adoc
+++ b/userguide/tutorials/plugin_installation.adoc
@@ -141,6 +141,16 @@ kpm install_java_plugin '<plugin-key>'
 * Replace `plugin-key` with the plugin name.
 * Replace `<group id>`, `<artifact_id>`, `<version>` with appropriate values from the binary repository.
 
+=== Installing via Aviate Marketplace
+
+The https://aviate.killbill.io[Aviate marketplace] provides a user-friendly interface to discover, install, and manage Kill Bill plugins directly from your browser. For this, you will need to have an Aviate Flock account and add your local KB instance as a deployment.
+
+Refer to the following demo for a walkthrough of the plugin installation process via the Aviate marketplace:
+
+:storylane-id: gxfjy9nl7zuo
+:storylane-embed-type: inline
+include::{sourcedir}/includes/storylane-embed.adoc[]
+
 === Installing via Plugin Management APIs
 
 Kill Bill provides several plugin management APIs which can be used to install/start/stop and take other actions on plugins. This is explained in detail in the https://docs.killbill.io/latest/plugin_management.html[_Plugin Management APIs_] document. 

--- a/userguide/tutorials/plugin_management.adoc
+++ b/userguide/tutorials/plugin_management.adoc
@@ -54,7 +54,7 @@ The installation of a plugin occurs through the KPM plugin (which itself relies 
 * Set that latest downloaded version as being the default one to start (`isSelectedForStart`)
 * Notify Kill Bill core to update its view of the existing plugins
 
-Example of installing the `paypal` plugin with a specified version of `4.0.0`:
+Example of installing the `braintree` plugin with a specified version of `1.0.2`:
 [source,bash]
 ----
 curl -v \
@@ -66,11 +66,11 @@ curl -v \
          "nodeCommandProperties": [
              {
                  "key": "pluginKey",
-                 "value": "paypal"
+                 "value": "braintree"
              },
              {
                  "key": "pluginVersion",
-                 "value": "4.0.0"
+                 "value": "1.0.2"
              }
          ],
          "nodeCommandType": "INSTALL_PLUGIN",
@@ -120,7 +120,7 @@ Starting a plugin occurs purely through Kill Bill (independent of the KPM plugin
 * Start the plugin
 * Update its view of the existing plugins
 
-Example of starting the default installed version for the `paypal` plugin:
+Example of starting the default installed version for the `braintree` plugin:
 
 [source,bash]
 ----
@@ -133,7 +133,7 @@ curl -v \
          "nodeCommandProperties": [
              {
                  "key": "pluginKey",
-                 "value": "paypal"
+                 "value": "braintree"
              }
          ],
          "nodeCommandType": "START_PLUGIN",
@@ -150,7 +150,7 @@ Stopping a plugin occurs purely through Kill Bill (independent of the KPM plugin
 * Unload the classes through the OSGI mechanism
 * Update its view of the existing plugins
 
-Example of stopping the running version of the  `paypal` plugin:
+Example of stopping the running version of the  `braintree` plugin:
 
 [source,bash]
 ----
@@ -163,7 +163,7 @@ curl -v \
          "nodeCommandProperties": [
              {
                  "key": "pluginKey",
-                 "value": "paypal"
+                 "value": "braintree"
              }
          ],
          "nodeCommandType": "STOP_PLUGIN",
@@ -176,7 +176,7 @@ curl -v \
 
 Restarting a plugin consists of first stopping the plugin and then restarting the plugin (therefore unloading previous classes and reloading new ones with a potentially different version).
 
-Example of restarting the running version of the  `paypal` plugin:
+Example of restarting the running version of the  `braintree` plugin:
 
 [source,bash]
 ----
@@ -189,7 +189,7 @@ curl -v \
          "nodeCommandProperties": [
              {
                  "key": "pluginKey",
-                 "value": "paypal"
+                 "value": "braintree"
              }
          ],
          "nodeCommandType": "RESTART_PLUGIN",
@@ -202,7 +202,7 @@ curl -v \
 
 Uninstalling a plugin consists of marking that plugin as being `disabled`. The code remains on the filesystem but Kill Bill will ignore it.
 
-Example of uninstalling the `paypal` plugin:
+Example of uninstalling version `1.0.2` of the `braintree` plugin:
 
 [source,bash]
 ----
@@ -215,7 +215,11 @@ curl -v \
          "nodeCommandProperties": [
              {
                  "key": "pluginKey",
-                 "value": "paypal"
+                 "value": "braintree"
+             },
+             {
+                 "key": "pluginVersion",
+                 "value": "1.0.2"
              }
          ],
          "nodeCommandType": "UNINSTALL_PLUGIN",


### PR DESCRIPTION
Includes the following:

- Add plugin installation via Aviate to the [Plugin Installation](https://docs.killbill.io/latest/plugin_installation) Doc (See 4fa19164ef8164710c245eedbe0a9faaccb45c59)
- Update [Plugin Management Doc](https://docs.killbill.io/latest/plugin_management) to use `Braintree` instead of `Paypal` (See 62fd8ed3468a844af250a67118b8c9f11ff3e0d0)
- Fix Storylane Demo links in [Getting Started](https://docs.killbill.io/latest/aviate-getting-started) Doc (See 410a1011f165b7cb4e1e0c6bc6f44dbffa2c81a7 and 60395e1)
- Add link to Storylane demos instead of embedding code in relevant docs (See 96aeda18c580636cb53dbdf21779d5374f65c709)
- Added Aviate Deployment Management doc. (See fb698a4)