### PR TITLE
Minor doc corrections

### DIFF
--- a/html5/_main_toc.html.slim
+++ b/html5/_main_toc.html.slim
@@ -74,9 +74,6 @@ nav.sidebar-nav
           a.nav-link href="/latest/userguide_payment.html"
             | Payment Processing
         li
-          a.nav-link href="/latest/userguide_configuration.html"
-            | Kill Bill Configuration
-        li
           a.nav-link href="/latest/internationalization.html"
             | Internationalization
         li
@@ -134,6 +131,9 @@ nav.sidebar-nav
           <path fill-rule="evenodd" clip-rule="evenodd" d="M10.5024 5.70711C10.1119 6.09763 9.47871 6.09763 9.08818 5.70711L5.7953 2.41421L2.50241 5.70711C2.11188 6.09763 1.47872 6.09763 1.0882 5.70711C0.697672 5.31658 0.697672 4.68342 1.0882 4.29289L5.08819 0.292893C5.47871 -0.0976311 6.11188 -0.0976311 6.5024 0.292893L10.5024 4.29289C10.8929 4.68342 10.8929 5.31658 10.5024 5.70711Z" fill="#D1D5DB"/>
         </svg>
       ul.nav.navbar-nav
+        li
+          a.nav-link href="/latest/userguide_configuration.html"
+            | Kill Bill Configuration
         li
           a.nav-link href="/latest/userguide_deployment.html"
             | Going to Production
@@ -430,4 +430,4 @@ nav.sidebar-nav
             | Invoice Subsystem
         li
           a.nav-link href="/latest/development.html"
-            | Development Environment
+            | Development Environment Setup

--- a/userguide/aviate/aviate-health.adoc
+++ b/userguide/aviate/aviate-health.adoc
@@ -97,77 +97,6 @@ The metrics exposed by the Aviate plugin can mainly be categorized in the follow
 
 |===
 
-=== Runtime Properties
-
-Properties can be specified to configure the Kill Bill system including its plugins. The following https://docs.killbill.io/latest/userguide_configuration#configuration_properties_table[documentation] shows the main configuration properties.
-
-The values for these properties can come from multiple sources, each with a defined precedence.
-
-==== Property Resolution Order (Highest to Lowest)
-Kill Bill resolves property values in the following order, where higher precedence sources override lower ones:
-
-* Immutable System Property
-
-Includes the `user.timezone` property, which is force set to `GMT`.
-
-This property cannot be overridden.
-
-* Environment Variables
-
-Properties prefixed with `KB_org_` (for example, `KB_org_killbill_dao_url` maps to `org.killbill.dao.url`).
-
-These are loaded only when `org.killbill.server.lookupEnvironmentVariables` is set to `true` (this is enabled by default).
-
-These properties take the highest precedence among other configurable sources.
-
-* Runtime Configuration
-
-Properties loaded from a configuration file specified via `-Dorg.killbill.server.properties=<propertyFile>`.
-
-If no file is specified, Kill Bill uses JVM system properties defined via `-Dproperty=value`.
-
-This source has the second-highest precedence among configurable sources.
-
-* Kill Bill Defaults
-
-These are default values defined within the Kill Bill codebase.
-
-They are registered dynamically by various *Config classes during application startup, covering configuration domains such as CatalogConfig, DaoConfig, LifecycleConfig, SecurityConfig, InvoiceConfig, PaymentConfig, OSGIConfig, and others.
-
-The following defaults are applied only when a property is not defined in any higher precedence source:
-
-----
-org.killbill.persistent.bus.external.tableName=bus_ext_events
-org.killbill.persistent.bus.external.historyTableName=bus_ext_events_history
-org.killbill.server.enableJasypt=false
-org.killbill.server.lookupEnvironmentVariables=true
-org.slf4j.simpleLogger.log.jdbc=ERROR
-----
-
-When a property is defined in multiple sources, Kill Bill applies the value from the highest precedence source and logs a warning indicating which sources defined it and which value was chosen.
-
-Example warning:
-
-----
-Property conflict detected for 'org.killbill.dao.healthCheckConnectionTimeout':
-defined in sources [RuntimeConfiguration, EnvironmentVariables] -
-using value from 'EnvironmentVariables': '11s'
-----
-
-
-To make it easier to understand the runtime values of these properties, Kill Bill provides the https://apidocs.killbill.io/aviate-health.html#retrieve-runtime-configuration[/v1/health/config] endpoint.
-This endpoint displays the effective configuration currently in use along with information about which source each property value was derived from.
-
-
-==== Per-Tenant Configuration
-
-In addition to system-wide properties, Kill Bill supports per-tenant configuration, allowing tenants to override specific system properties for their own environment.
-
-This provides fine-grained control in multi-tenant deployments, enabling different tenants to customize selected settings while still inheriting defaults from the global configuration.
-
-For more details, see the official documentation: https://docs.killbill.io/latest/userguide_configuration#_per_tenant_properties.
-
-
 === Queue Metrics
 
 Queue metrics can be used to assess the health of the Kill Bill internal queues.
@@ -313,6 +242,76 @@ The following metrics are timer metrics and provide different data points for th
 
 |===
 
+
+== Runtime Properties
+
+Properties can be specified to configure the Kill Bill system including its plugins. The following https://docs.killbill.io/latest/userguide_configuration#configuration_properties_table[documentation] shows the main configuration properties.
+
+The values for these properties can come from multiple sources, each with a defined precedence.
+
+=== Property Resolution Order (Highest to Lowest)
+Kill Bill resolves property values in the following order, where higher precedence sources override lower ones:
+
+* Immutable System Property
+
+Includes the `user.timezone` property, which is force set to `GMT`.
+
+This property cannot be overridden.
+
+* Environment Variables
+
+Properties prefixed with `KB_org_` (for example, `KB_org_killbill_dao_url` maps to `org.killbill.dao.url`).
+
+These are loaded only when `org.killbill.server.lookupEnvironmentVariables` is set to `true` (this is enabled by default).
+
+These properties take the highest precedence among other configurable sources.
+
+* Runtime Configuration
+
+Properties loaded from a configuration file specified via `-Dorg.killbill.server.properties=<propertyFile>`.
+
+If no file is specified, Kill Bill uses JVM system properties defined via `-Dproperty=value`.
+
+This source has the second-highest precedence among configurable sources.
+
+* Kill Bill Defaults
+
+These are default values defined within the Kill Bill codebase.
+
+They are registered dynamically by various *Config classes during application startup, covering configuration domains such as CatalogConfig, DaoConfig, LifecycleConfig, SecurityConfig, InvoiceConfig, PaymentConfig, OSGIConfig, and others.
+
+The following defaults are applied only when a property is not defined in any higher precedence source:
+
+----
+org.killbill.persistent.bus.external.tableName=bus_ext_events
+org.killbill.persistent.bus.external.historyTableName=bus_ext_events_history
+org.killbill.server.enableJasypt=false
+org.killbill.server.lookupEnvironmentVariables=true
+org.slf4j.simpleLogger.log.jdbc=ERROR
+----
+
+When a property is defined in multiple sources, Kill Bill applies the value from the highest precedence source and logs a warning indicating which sources defined it and which value was chosen.
+
+Example warning:
+
+----
+Property conflict detected for 'org.killbill.dao.healthCheckConnectionTimeout':
+defined in sources [RuntimeConfiguration, EnvironmentVariables] -
+using value from 'EnvironmentVariables': '11s'
+----
+
+
+To make it easier to understand the runtime values of these properties, Kill Bill provides the https://apidocs.killbill.io/aviate-health.html#retrieve-runtime-configuration[/v1/health/config] endpoint.
+This endpoint displays the effective configuration currently in use along with information about which source each property value was derived from.
+
+
+=== Per-Tenant Configuration
+
+In addition to system-wide properties, Kill Bill supports per-tenant configuration, allowing tenants to override specific system properties for their own environment.
+
+This provides fine-grained control in multi-tenant deployments, enabling different tenants to customize selected settings while still inheriting defaults from the global configuration.
+
+For more details, see the official documentation: https://docs.killbill.io/latest/userguide_configuration#_per_tenant_properties.
 
 == Sample API Requests and Responses
 

--- a/userguide/aviate/how-to-install-the-aviate-plugin.adoc
+++ b/userguide/aviate/how-to-install-the-aviate-plugin.adoc
@@ -78,6 +78,7 @@ com.killbill.billing.plugin.aviate.enableMigrations=false
 ----
 
 When this property has been set to false, latest schema can be installed manually from the following links - depending on your database engine:
+
 * https://docs.killbill.io/latest/aviate-mysql-ddl.sql[Aviate MySQL DDL]
 * https://docs.killbill.io/latest/aviate-postgresql-ddl.sql[Aviate PostgreSQL DDL]
 

--- a/userguide/tutorials/email-notification-plugin.adoc
+++ b/userguide/tutorials/email-notification-plugin.adoc
@@ -37,7 +37,7 @@ To send an email the following is required:
 
 == Plugin Installation
 
-A plugin can be installed either via https://docs.killbill.io/latest/userguide_kaui.html[__Kaui__] or https://github.com/killbill/killbill-cloud/blob/master/kpm[_KPM_]. In order to install a plugin via Kaui, please refer to the https://docs.killbill.io/latest/plugin_installation.html#_installing_via_kaui[__Plugin Installation Instructions__] document. In order to install a plugin via kpm, you may follow the steps given below:
+A plugin can be installed either via https://docs.killbill.io/latest/plugin_installation.html#_installing_via_kaui[__Kaui__] or https://github.com/killbill/killbill-cloud/blob/master/kpm[__KPM__] or https://docs.killbill.io/latest/plugin_installation#_installing_via_aviate_marketplace[_Aviate UI_]. In order to install a plugin via kpm, you may follow the steps given below:
 
 . Ensure that you have kpm installed as explained https://github.com/killbill/killbill-cloud/tree/master/kpm#kpm-installation[here].
 
@@ -46,7 +46,7 @@ A plugin can be installed either via https://docs.killbill.io/latest/userguide_k
 kpm install_java_plugin email-notifications --destination=<path_to_install_plugin>
 
 . Verify that the plugin is installed properly. This can be done by ensuring that the plugin JAR is present at the `path_to_install_plugin` specified in the previous step. Alternatively, you can also open `kpm` in https://docs.killbill.io/latest/userguide_kaui.html[Kaui] and verify that the email notification plugin is running as follows:
-
++
 image::https://github.com/killbill/killbill-docs/raw/v3/userguide/assets/img/email-notification-plugin/kaui_email_notification_plugin.png[align=center]
 
 . If you would like to make changes to the plugin, you can clone the plugin code, build and deploy it as explained https://github.com/killbill/killbill-email-notifications-plugin[here].

--- a/userguide/tutorials/plugin_installation.adoc
+++ b/userguide/tutorials/plugin_installation.adoc
@@ -143,7 +143,7 @@ kpm install_java_plugin '<plugin-key>'
 
 === Installing via Aviate Marketplace
 
-The https://aviate.killbill.io[Aviate marketplace] provides a user-friendly interface to discover, install, and manage Kill Bill plugins directly from your browser. For this, you will need to have an Aviate Flock account and add your local KB instance as a deployment.
+The https://aviate.killbill.io[Aviate marketplace] provides a user-friendly interface to discover, install, and manage Kill Bill plugins directly from your browser. For this, you will need to have an Aviate Flock account and add your local KB instance as a deployment. Refer to https://docs.killbill.io/latest/aviate-deployment-management[_Aviate Deployment Management documentation] for more details on how add your local KB instance as a deployment.
 
 Refer to the following demo for a walkthrough of the plugin installation process via the Aviate marketplace:
 


### PR DESCRIPTION
Minor doc corrections:

- Move Configuration docs to `Deploy and Operate` section
- Remove runtime properties section from metrics section in heath doc
- Other minor corrections