### PR TITLE
Move llms.txt and SKILL.md to site root

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Kill Bill
+name: killbill
 description: Use when working with the Kill Bill open source billing and payments platform. This skill helps with subscriptions, invoices, payments, catalog configuration, plugins, APIs, Kaui administration, tenant configuration, and Java plugin development.
 metadata:
   version: "1.0"
@@ -17,7 +17,7 @@ Kill Bill is an open-source subscription billing and payments platform. It handl
 - Client libraries: `killbill-client-java`, `killbill-client-python`, `killbill-client-ruby`, `killbill-client-js`
 - Plugin manager (KPM): Used to install plugins using `kpm install_java_plugin <plugin-name>`
 - Docker: `killbill/killbill` and `killbill/kaui` images
-- - MCP server: `apidocs-mcp.killbill.io` — provides direct access to Kill Bill API documentation; can generate accurate, up-to-date API usage examples and scripts
+- MCP server: `https://apidocs-mcp.killbill.io/mcp` — provides direct access to Kill Bill API documentation; can generate accurate, up-to-date API usage examples and scripts
 
 **Authentication:** HTTP Basic Auth (`-u <username>:<password>`) plus required multi-tenancy headers `X-Killbill-ApiKey` and `X-Killbill-ApiSecret`. Every mutating call should also include `X-Killbill-CreatedBy` (and optionally `X-Killbill-Reason` / `X-Killbill-Comment`).
 
@@ -55,20 +55,20 @@ Use this skill whenever users ask about:
 
 When answering questions:
 
-1. On loading this skill, check whether an MCP connector for `apidocs-mcp.killbill.io` is available/connected. If it is not connected, ask the user whether they'd like to connect it before proceeding — it provides direct, current API documentation and can generate accurate code snippets, reducing reliance on this skill's own static examples or on web search.
+1. On loading this skill, check whether an MCP connector for `https://apidocs-mcp.killbill.io/mcp` is available/connected. If it is not connected, ask the user whether they'd like to connect it before proceeding — it provides direct, current API documentation and can generate accurate code snippets, reducing reliance on this skill's own static examples or on web search.
 2. Prefer official Kill Bill documentation over assumptions.
-2. Mention version-specific behavior when relevant.
-3. If multiple approaches exist, recommend the simplest supported approach first.
-4. Prefer configuration over custom code when possible.
-5. When discussing plugins, clearly distinguish between:
+3. Mention version-specific behavior when relevant.
+4. If multiple approaches exist, recommend the simplest supported approach first.
+5. Prefer configuration over custom code when possible.
+6. When discussing plugins, clearly distinguish between:
    - Kill Bill core
    - Kaui
    - Payment plugins
    - Notification plugins
    - Open source plugins (Like Stripe, Adyen, Braintree, etc.)
    - Private/Custom plugins
-6. Use official REST API endpoints whenever applicable.
-7. For Java development, prefer the supported Kill Bill plugin APIs rather than internal implementation classes.
+7. Use official REST API endpoints whenever applicable.
+8. For Java development, prefer the supported Kill Bill plugin APIs rather than internal implementation classes.
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,6 +2,11 @@
 
 > Official documentation for Kill Bill, Kaui and plugins.
 
+## Agent Resources
+
+- https://docs.killbill.io/SKILL.md — Kill Bill Agent Skill: product summary, API authentication, common workflows and quick reference. Install as `SKILL.md` in a skill directory named `killbill`.
+- https://apidocs-mcp.killbill.io/mcp — MCP server providing direct access to the Kill Bill API documentation; prefer it over static examples for accurate, up-to-date API usage and generated scripts.
+
 ## Understand Kill Bill and Getting Started with Kill Bill
 
 - https://docs.killbill.io/latest/what_is_kill_bill.html — High-level overview of what Kill Bill is and the problems it solves.


### PR DESCRIPTION
## Problem

`https://docs.killbill.io/llms.txt` returns the 38 KB root `index.html` fallback instead of the file. PR #690 landed the content under `latest/`, so it is published at `/latest/llms.txt`.

The `llms.txt` convention (llmstxt.org) fixes the location at the **origin root**, and that is the entire discovery mechanism — no `<link rel>` tag, no `robots.txt` directive, no registry. Consumers concatenate `origin + "/llms.txt"` and fetch. Nothing ever probes subdirectories, so `/latest/llms.txt` is undiscoverable in practice.

## Changes

- Move `latest/llms.txt` → `llms.txt` and `latest/skill.md` → `SKILL.md`, alongside the other hand-maintained root files (`index.html`, `favicon.ico`, `latest.txt`, `deprecate_version.sh`). `latest/` is machine-generated territory — `update_gh-pages.sh` copies the full build output into it on every deploy — and both files are inherently versionless.
- Rename to `SKILL.md` to match the Agent Skills on-disk filename, so installing is a download rather than a download-and-rename.
- **Fix invalid skill name:** `name: Kill Bill` → `killbill`. The field must be lowercase-kebab-case and match the skill directory name; as written the skill would fail to load.
- Fix the doubled `- -` list marker and the duplicate list numbering introduced in 91dd67db4 (`2.` and `6.` each appeared twice).
- Correct the MCP endpoint to `https://apidocs-mcp.killbill.io/mcp` (the bare host was listed).
- Add an **Agent Resources** section to `llms.txt` linking `SKILL.md` and the MCP server. `llms.txt` previously referenced neither, which left `SKILL.md` undiscoverable even once relocated.

## Notes

No redirects included: nothing in the repo or the built site links to either file, so the move breaks no inbound links. Note that URLs are case-sensitive here — `/latest/SKILL.md` 404s today while `/latest/skill.md` resolves.

## Verification after deploy

```
curl -sI https://docs.killbill.io/llms.txt   # expect text/plain
curl -sI https://docs.killbill.io/SKILL.md   # expect text/markdown
```

Both currently return `text/html` (the `index.html` fallback).

## Follow-up (not in this PR)

These files live only on `gh-pages` and nothing regenerates them, so they will drift as pages are added or renamed — every link inside `llms.txt` hardcodes `/latest/`, so a renamed page becomes a silent dead link. Worth moving the sources onto `v3` and having `make.sh` emit them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)