### PR TITLE
Changes for https://github.com/killbill/technical-support/issues/300

### DIFF
--- a/userguide/aviate/aviate-catalog-guide.adoc
+++ b/userguide/aviate/aviate-catalog-guide.adoc
@@ -6,6 +6,9 @@ The https://aviate.killbill.io[Aviate Catalog UI] allows you to create individua
 This provides much finer granularity than the Kill Bill open-source model, which requires creating a new catalog version for any change. As a result, this approach is more dynamic and scales significantly better when managing a large number of catalog entries.
 Internally, the UI uses the https://apidocs.killbill.io/aviate-catalog[Aviate Catalog APIs].
 
+[NOTE]
+Before creating a catalog via the Aviate UI, a deployment must be added. See the https://docs.killbill.io/latest/aviate-deployment-management[Aviate Deployment Management] guide for details.
+
 == Create Product,Plan, Pricelist
 
 To create a product, plan, and pricelist:

--- a/userguide/aviate/aviate-catalog-plugin.adoc
+++ b/userguide/aviate/aviate-catalog-plugin.adoc
@@ -20,20 +20,9 @@ This section provides a step-by-step approach to get started with the Aviate Cat
 
 The Aviate plugin can be installed as documented in the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[How to Install the Aviate Plugin] doc.
 
-=== Enabling Catalog APIs
-
-To use the catalog API capabilities provided by the Aviate plugin, ensure that KB is started with the following property:
-
-[source,bash]
-----
-com.killbill.billing.plugin.aviate.enableCatalogApis=true
-----
-
-Refer to the https://docs.killbill.io/latest/userguide_configuration.html[__Kill Bill Configuration Guide__] to know more about setting configuration properties.
-
 === Using Catalog Plugin APIs
 
-Once the plugin is installed and enabled, you can start using the Catalog Plugin APIs. As mentioned earlier, the Aviate catalog plugin exposes endpoints that operate at a plan/product/pricelist level. These endpoints allow plan/product/pricelist creation/modification and deletion. At the time of writing, only plan-level endpoints are supported. The catalog API endpoints are documented in our https://apidocs.killbill.io/aviate-catalog[api docs].
+Once the plugin is installed, you can start using the Catalog Plugin APIs. As mentioned earlier, the Aviate catalog plugin exposes endpoints that operate at a plan/product/pricelist level. These endpoints allow plan/product/pricelist creation/modification and deletion. At the time of writing, only plan-level endpoints are supported. The catalog API endpoints are documented in our https://apidocs.killbill.io/aviate-catalog[api docs].
 
 == Catalog Versioning
 

--- a/userguide/aviate/aviate-catalog-plugin.adoc
+++ b/userguide/aviate/aviate-catalog-plugin.adoc
@@ -20,6 +20,9 @@ This section provides a step-by-step approach to get started with the Aviate Cat
 
 The Aviate plugin can be installed as documented in the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[How to Install the Aviate Plugin] doc.
 
+[NOTE]
+The Catalog APIs are enabled by default. This behavior is controlled by the `com.killbill.billing.plugin.aviate.enableCatalogApis` property. Refer to the https://docs.killbill.io/latest/userguide_configuration.html[Kill Bill Configuration Guide] to know more about setting configuration properties.s
+
 === Using Catalog Plugin APIs
 
 Once the plugin is installed, you can start using the Catalog Plugin APIs. As mentioned earlier, the Aviate catalog plugin exposes endpoints that operate at a plan/product/pricelist level. These endpoints allow plan/product/pricelist creation/modification and deletion. At the time of writing, only plan-level endpoints are supported. The catalog API endpoints are documented in our https://apidocs.killbill.io/aviate-catalog[api docs].

--- a/userguide/aviate/aviate-coupons.adoc
+++ b/userguide/aviate/aviate-coupons.adoc
@@ -12,6 +12,9 @@ As a billing administrator or marketing manager, you need to offer discounts to 
 
 This guide walks through creating, retrieving, listing, and archiving coupons, and shows how to apply a coupon when creating a subscription.
 
+[NOTE]
+Coupons are currently managed via the API only — there is no Aviate UI for creating or managing coupons. All examples in this guide use `curl`.
+
 == Prerequisites
 
 * A running Kill Bill instance with the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[Aviate plugin installed].
@@ -305,9 +308,8 @@ After completing the steps above, confirm the following:
 
 1. **Plan-scoped coupon applied to a different plan** — the coupon is silently ignored and no discount appears on the invoice. Double-check the `planList` values match the subscription's `planName`.
 2. **Using a coupon after its `expirationDate`** — the API returns an error. Update or create a new coupon with a later expiration.
-3. **Forgetting `enableCouponsApis=true`** — all coupon endpoints return `404 Not Found`. Ensure the system property is set before starting Kill Bill.
-4. **Using `DISCOUNT_TYPE_FIXED` without `discountPrice`** — the API returns `400 Bad Request`. Both `discountPrice` and `discountCurrency` are required for fixed-amount coupons.
-5. **Applying multiple coupons** — only the first coupon is applied. If you need to stack discounts, combine them into a single coupon or use wallet credits instead.
+3. **Using `DISCOUNT_TYPE_FIXED` without `discountPrice`** — the API returns `400 Bad Request`. Both `discountPrice` and `discountCurrency` are required for fixed-amount coupons.
+4. **Applying multiple coupons** — only the first coupon is applied. If you need to stack discounts, combine them into a single coupon or use wallet credits instead.
 
 == API Reference
 

--- a/userguide/aviate/aviate-coupons.adoc
+++ b/userguide/aviate/aviate-coupons.adoc
@@ -15,14 +15,6 @@ This guide walks through creating, retrieving, listing, and archiving coupons, a
 == Prerequisites
 
 * A running Kill Bill instance with the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[Aviate plugin installed].
-* The coupon feature flag enabled — start Kill Bill with the following system property:
-+
-[source,bash]
-----
-com.killbill.billing.plugin.aviate.enableCouponsApis=true
-----
-+
-For details on setting configuration properties, refer to the https://docs.killbill.io/latest/userguide_configuration.html[Kill Bill Configuration Guide].
 * A valid JWT ID token (see https://docs.killbill.io/latest/aviate-authentication.html[Aviate Authentication]).
 * At least one plan in the catalog (see https://docs.killbill.io/latest/aviate-catalog-guide.html[Aviate Catalog Guide]).
 

--- a/userguide/aviate/aviate-coupons.adoc
+++ b/userguide/aviate/aviate-coupons.adoc
@@ -21,6 +21,9 @@ Coupons are currently managed via the API only — there is no Aviate UI for cre
 * A valid JWT ID token (see https://docs.killbill.io/latest/aviate-authentication.html[Aviate Authentication]).
 * At least one plan in the catalog (see https://docs.killbill.io/latest/aviate-catalog-guide.html[Aviate Catalog Guide]).
 
+[NOTE]
+The Coupon APIs are enabled by default. This behavior is controlled by the `com.killbill.billing.plugin.aviate.enableCouponsApis` property. Refer to the https://docs.killbill.io/latest/userguide_configuration.html[Kill Bill Configuration Guide] to know more about setting configuration properties.
+
 == Coupon Attributes Reference
 
 Each coupon is defined by the following fields:

--- a/userguide/aviate/aviate-custom-invoice-sequencing.adoc
+++ b/userguide/aviate/aviate-custom-invoice-sequencing.adoc
@@ -16,15 +16,6 @@ This section provides a step-by-step approach to get started with Aviate Custom 
 
 The Aviate plugin can be installed as documented in the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[How to Install the Aviate Plugin] doc.
 
-=== Enabling Aviate Custom Invoice Sequencing
-
-To use the custom invoice sequencing feature provided by the Aviate plugin, ensure that KB is started with the following property:
-
-[source, bash]
-----
-com.killbill.billing.plugin.aviate.enableCustomInvoiceSequencing=true
-----
-
 === Tenant-level Configuration
 
 In addition, the Aviate Custom Invoicing feature requires some tenant-level configuration.  This can be done by executing the https://apidocs.killbill.io/tenant.html#add-a-per-tenant-configuration-for-a-plugin[per-tenant configuration] endpoint as follows:

--- a/userguide/aviate/aviate-custom-invoice-sequencing.adoc
+++ b/userguide/aviate/aviate-custom-invoice-sequencing.adoc
@@ -16,6 +16,9 @@ This section provides a step-by-step approach to get started with Aviate Custom 
 
 The Aviate plugin can be installed as documented in the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[How to Install the Aviate Plugin] doc.
 
+[NOTE]
+Custom invoice sequencing is enabled by default. This behavior is controlled by the `com.killbill.billing.plugin.aviate.enableCustomInvoiceSequencing` property. Refer to the https://docs.killbill.io/latest/userguide_configuration.html[Kill Bill Configuration Guide] to know more about setting configuration properties.
+
 === Tenant-level Configuration
 
 In addition, the Aviate Custom Invoicing feature requires some tenant-level configuration.  This can be done by executing the https://apidocs.killbill.io/tenant.html#add-a-per-tenant-configuration-for-a-plugin[per-tenant configuration] endpoint as follows:

--- a/userguide/aviate/aviate-getting-started.adoc
+++ b/userguide/aviate/aviate-getting-started.adoc
@@ -29,17 +29,15 @@ In short:
 
 ''''
 
-== Step 1: Start in Aviate (Get Started)
+== Step 1: Start in Aviate (Onboarding)
 
-When you first log into Aviate, you land on the *Get Started* screen.
+When you first log into Aviate, the sidebar shows an *Onboarding* checklist ("Everything you need to start billing") that tracks your setup progress.
 
-This checklist guides you through the minimum required setup to bill customers.
+Before working through it, configure your organization settings as described below.
 
-You should complete all steps in order.
+=== Configure Organization Settings
 
-=== Configure Company Settings
-
-This step defines who you are as a business.
+This step defines who you are as a business. Organization settings are available in Aviate under *Configuration -> Settings*, on the *Organization* tab. Here you can enter your company information (name, address, country, URL), which is later reused on invoices, emails, and quotes.
 
 For the purpose of this guide, use the following fictive company:
 
@@ -49,9 +47,7 @@ For the purpose of this guide, use the following fictive company:
   ** United Kingdom (GBP)
   ** France (EUR)
 
-This information is later reused on invoices and customer communications.
-
-The following demo shows how you can configure the company settings via Aviate.
+The following demo shows how you can configure the organization settings via Aviate.
 
 :storylane-id: eykmjqwtc4vf
 :storylane-embed-type: popup

--- a/userguide/aviate/aviate-health.adoc
+++ b/userguide/aviate/aviate-health.adoc
@@ -18,19 +18,6 @@ This section provides a step-by-step approach to start using Aviate Health.
 
 The Aviate plugin can be installed as documented in the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[How to Install the Aviate Plugin] doc.
 
-=== Enabling Aviate Health
-
-When the Aviate plugin is installed, Aviate Heath is enabled by default.
-
-The following configuration property controls this feature:
-
-[source,bash]
-----
-com.killbill.billing.plugin.aviate.enableHealthReporter=true
-----
-
-Refer to the https://docs.killbill.io/latest/userguide_configuration.html[__Kill Bill Configuration Guide__] to know more about setting configuration properties.
-
 === Using Health APIs
 
 As mentioned earlier, Aviate Health exposes endpoints that allow monitoring the health of a KB installation and fixing problems if any. Once the aviate plugin is installed, you can start using the Aviate Health APIs. These are documented in our https://apidocs.killbill.io/aviate-health[api docs].

--- a/userguide/aviate/aviate-health.adoc
+++ b/userguide/aviate/aviate-health.adoc
@@ -18,6 +18,9 @@ This section provides a step-by-step approach to start using Aviate Health.
 
 The Aviate plugin can be installed as documented in the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[How to Install the Aviate Plugin] doc.
 
+[NOTE]
+The Aviate health reporter is enabled by default. This behavior is controlled by the `com.killbill.billing.plugin.aviate.enableHealthReporter` property. Refer to the https://docs.killbill.io/latest/userguide_configuration.html[Kill Bill Configuration Guide] to know more about setting configuration properties.
+
 === Using Health APIs
 
 As mentioned earlier, Aviate Health exposes endpoints that allow monitoring the health of a KB installation and fixing problems if any. Once the aviate plugin is installed, you can start using the Aviate Health APIs. These are documented in our https://apidocs.killbill.io/aviate-health[api docs].

--- a/userguide/aviate/aviate-metering.adoc
+++ b/userguide/aviate/aviate-metering.adoc
@@ -17,14 +17,6 @@ The https://apidocs.killbill.io/usage[Kill Bill core usage APIs] support recordi
 Before using the metering APIs, ensure the following:
 
 * The Aviate plugin is installed (see the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[How to Install the Aviate Plugin] guide).
-* Kill Bill is started with the metering feature flag enabled:
-+
-[source,bash]
-----
-com.killbill.billing.plugin.aviate.enableMeteringApis=true
-----
-+
-Refer to the https://docs.killbill.io/latest/userguide_configuration.html[Kill Bill Configuration Guide] for setting configuration properties.
 * You have a valid ID token for authentication (see https://docs.killbill.io/latest/aviate-authentication.html[Authentication]).
 * For invoicing: a catalog with a usage-based plan exists (see https://docs.killbill.io/latest/aviate-catalog-guide.html[Catalog Guide — Creating Usage Plans]).
 

--- a/userguide/aviate/aviate-metering.adoc
+++ b/userguide/aviate/aviate-metering.adoc
@@ -20,6 +20,9 @@ Before using the metering APIs, ensure the following:
 * You have a valid ID token for authentication (see https://docs.killbill.io/latest/aviate-authentication.html[Authentication]).
 * For invoicing: a catalog with a usage-based plan exists (see https://docs.killbill.io/latest/aviate-catalog-guide.html[Catalog Guide — Creating Usage Plans]).
 
+[NOTE]
+The Metering APIs are enabled by default. This behavior is controlled by the `com.killbill.billing.plugin.aviate.enableUsageApis` property. Refer to the https://docs.killbill.io/latest/userguide_configuration.html[Kill Bill Configuration Guide] to know more about setting configuration properties.
+
 == Key Concepts
 
 === Billing Meters

--- a/userguide/aviate/aviate-tax.adoc
+++ b/userguide/aviate/aviate-tax.adoc
@@ -22,6 +22,9 @@ This section provides a step-by-step approach to get started with Aviate Tax.
 
 The Aviate plugin can be installed as documented in the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[How to Install the Aviate Plugin] doc.
 
+[NOTE]
+Aviate Tax is enabled by default. This behavior is controlled by the `com.killbill.billing.plugin.aviate.enableTax` property. Refer to the https://docs.killbill.io/latest/userguide_configuration.html[Kill Bill Configuration Guide] to know more about setting configuration properties.
+
 === Tenant-level Configuration
 
 The Aviate Tax feature requires some tenant-level configuration.  This can be done via the Aviate UI:

--- a/userguide/aviate/aviate-tax.adoc
+++ b/userguide/aviate/aviate-tax.adoc
@@ -22,16 +22,9 @@ This section provides a step-by-step approach to get started with Aviate Tax.
 
 The Aviate plugin can be installed as documented in the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[How to Install the Aviate Plugin] doc.
 
-=== Enabling Aviate Tax
+=== Tenant-level Configuration
 
-To use the tax feature provided by the Aviate plugin, ensure that KB is started with the following property:
-
-[source, bash]
-----
-com.killbill.billing.plugin.aviate.enableTax=true
-----
-
-In addition, the Aviate Tax feature requires some tenant-level configuration.  This can be done via the Aviate UI:
+The Aviate Tax feature requires some tenant-level configuration.  This can be done via the Aviate UI:
 
 :storylane-id: dmenqdn2zcoy
 :storylane-embed-type: popup

--- a/userguide/aviate/aviate-wallet.adoc
+++ b/userguide/aviate/aviate-wallet.adoc
@@ -18,6 +18,9 @@ This guide walks through creating a wallet, checking balances, adding credits, a
 * A valid JWT ID token (see https://docs.killbill.io/latest/aviate-authentication.html[Aviate Authentication]).
 * A Kill Bill account with a default payment method (required for paid credits and top-off). See https://docs.killbill.io/latest/aviate-billing-account.html[Aviate Billing Accounts].
 
+[NOTE]
+The Wallet APIs are enabled by default. This behavior is controlled by the `com.killbill.billing.plugin.aviate.enableWalletApis` property. Refer to the https://docs.killbill.io/latest/userguide_configuration.html[Kill Bill Configuration Guide] to know more about setting configuration properties.
+
 == Key Concepts
 
 === Balance vs. Live Balance

--- a/userguide/aviate/aviate-wallet.adoc
+++ b/userguide/aviate/aviate-wallet.adoc
@@ -15,14 +15,6 @@ This guide walks through creating a wallet, checking balances, adding credits, a
 == Prerequisites
 
 * A running Kill Bill instance with the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[Aviate plugin installed].
-* The wallet feature flag enabled — start Kill Bill with the following system property:
-+
-[source,bash]
-----
-com.killbill.billing.plugin.aviate.enableWalletApis=true
-----
-+
-For details on setting configuration properties, refer to the https://docs.killbill.io/latest/userguide_configuration.html[Kill Bill Configuration Guide].
 * A valid JWT ID token (see https://docs.killbill.io/latest/aviate-authentication.html[Aviate Authentication]).
 * A Kill Bill account with a default payment method (required for paid credits and top-off). See https://docs.killbill.io/latest/aviate-billing-account.html[Aviate Billing Accounts].
 

--- a/userguide/preview/aviate-contracts.adoc
+++ b/userguide/preview/aviate-contracts.adoc
@@ -72,18 +72,9 @@ The schedule execution engine automatically processes these milestones, triggeri
 
 Install the Aviate plugin as described in the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[How to Install the Aviate Plugin] guide.
 
-=== Enabling Contracts
-
-To enable the contract management APIs, start Kill Bill with the following system property:
-
-[source,bash]
-----
-com.killbill.billing.plugin.aviate.enableContractApis=true
-----
-
 === Using Contract APIs
 
-Once enabled, the contract APIs are available at `/plugins/aviate-plugin/v1/contracts`. Full API documentation is available at https://apidocs.killbill.io/aviate-contracts[our API documentation].
+The contract APIs are available at `/plugins/aviate-plugin/v1/contracts`. Full API documentation is available at https://apidocs.killbill.io/aviate-contracts[our API documentation].
 
 == Creating a Contract
 
@@ -216,6 +207,16 @@ The schedule execution engine runs automatically in the background, processing m
 * *Termination processing* -- outstanding obligations are settled and subscriptions are cancelled
 
 You do not need to manually trigger any of these actions -- they are handled by the schedule engine.
+
+[NOTE]
+Schedule execution is disabled by default. To enable it, start Kill Bill with the following system property:
+
+[source,bash]
+----
+com.killbill.billing.plugin.aviate.enableContractSchedules=true
+----
+
+For details on setting configuration properties, refer to the https://docs.killbill.io/latest/userguide_configuration.html[Kill Bill Configuration Guide].
 
 == Quote -> Order -> Contract Flow
 

--- a/userguide/preview/aviate-product-catalog.adoc
+++ b/userguide/preview/aviate-product-catalog.adoc
@@ -62,6 +62,9 @@ Multiple prices can be attached to a single offering to support multi-currency p
 
 Install the Aviate plugin as described in the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[How to Install the Aviate Plugin] guide.
 
+[NOTE]
+The Product Catalog APIs are enabled by default. This behavior is controlled by the `com.killbill.billing.plugin.aviate.enableCatalogApis` property. Refer to the https://docs.killbill.io/latest/userguide_configuration.html[Kill Bill Configuration Guide] to know more about setting configuration properties.
+
 === Using Catalog APIs
 
 You can interact with the Product Catalog using its REST API. Full API documentation is available at https://apidocs.killbill.io/aviate-catalog[our API documentation].

--- a/userguide/preview/aviate-product-catalog.adoc
+++ b/userguide/preview/aviate-product-catalog.adoc
@@ -62,20 +62,9 @@ Multiple prices can be attached to a single offering to support multi-currency p
 
 Install the Aviate plugin as described in the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[How to Install the Aviate Plugin] guide.
 
-=== Enabling the Product Catalog
-
-To enable the Product Catalog APIs, start Kill Bill with the following system property:
-
-[source,bash]
-----
-com.killbill.billing.plugin.aviate.enableCatalogApis=true
-----
-
-For details on setting configuration properties, refer to the https://docs.killbill.io/latest/userguide_configuration.html[Kill Bill Configuration Guide].
-
 === Using Catalog APIs
 
-Once enabled, you can interact with the Product Catalog using its REST API. Full API documentation is available at https://apidocs.killbill.io/aviate-catalog[our API documentation].
+You can interact with the Product Catalog using its REST API. Full API documentation is available at https://apidocs.killbill.io/aviate-catalog[our API documentation].
 
 == Creating Your First Product
 

--- a/userguide/preview/aviate-quotes-orders.adoc
+++ b/userguide/preview/aviate-quotes-orders.adoc
@@ -28,15 +28,6 @@ include::{sourcedir}/preview/includes/diagram-quotes-orders.adoc[]
 
 Install the Aviate plugin as described in the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[How to Install the Aviate Plugin] guide.
 
-=== Enabling Quotes & Orders
-
-To enable the enhanced quote functionality, start Kill Bill with the following system property:
-
-[source,bash]
-----
-com.killbill.billing.plugin.aviate.enableQuoteApis=true
-----
-
 === Using Quote APIs
 
 Full API documentation is available at https://apidocs.killbill.io/aviate-quotes[our API documentation].

--- a/userguide/preview/aviate-quotes-orders.adoc
+++ b/userguide/preview/aviate-quotes-orders.adoc
@@ -28,6 +28,9 @@ include::{sourcedir}/preview/includes/diagram-quotes-orders.adoc[]
 
 Install the Aviate plugin as described in the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[How to Install the Aviate Plugin] guide.
 
+[NOTE]
+The Quote APIs are enabled by default. This behavior is controlled by the `com.killbill.billing.plugin.aviate.enableQuoteApis` property. Refer to the https://docs.killbill.io/latest/userguide_configuration.html[Kill Bill Configuration Guide] to know more about setting configuration properties.
+
 === Using Quote APIs
 
 Full API documentation is available at https://apidocs.killbill.io/aviate-quotes[our API documentation].

--- a/userguide/preview/aviate-usage-rating.adoc
+++ b/userguide/preview/aviate-usage-rating.adoc
@@ -57,6 +57,9 @@ Expressions run in a secure sandbox with no access to the file system, network, 
 
 Install the Aviate plugin as described in the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[How to Install the Aviate Plugin] guide.
 
+[NOTE]
+Usage rating is enabled by default. This behavior is controlled by the `com.killbill.billing.plugin.aviate.enableUsageApis` property. Refer to the https://docs.killbill.io/latest/userguide_configuration.html[Kill Bill Configuration Guide] to know more about setting configuration properties.s
+
 === Using Usage Rating APIs
 
 Full API documentation is available at https://apidocs.killbill.io/aviate-usage-rating[our API documentation].

--- a/userguide/preview/aviate-usage-rating.adoc
+++ b/userguide/preview/aviate-usage-rating.adoc
@@ -254,6 +254,3 @@ When Kill Bill generates an invoice for a subscription with usage:
 . The resulting billable amounts appear as invoice line items
 
 You do not need to manually trigger rating -- it happens automatically as part of Kill Bill's standard invoice generation process.
-
-[NOTE]
-*Note:* The usage rating engine must be enabled via the `enableUsageRating` system property. When disabled, usage billing falls back to Kill Bill's built-in behavior.

--- a/userguide/preview/aviate-usage-rating.adoc
+++ b/userguide/preview/aviate-usage-rating.adoc
@@ -57,17 +57,6 @@ Expressions run in a secure sandbox with no access to the file system, network, 
 
 Install the Aviate plugin as described in the https://docs.killbill.io/latest/how-to-install-the-aviate-plugin.html[How to Install the Aviate Plugin] guide.
 
-=== Enabling Usage Rating
-
-To enable the usage rating engine, start Kill Bill with the following system property:
-
-[source,bash]
-----
-com.killbill.billing.plugin.aviate.enableUsageRating=true
-----
-
-For details on setting configuration properties, refer to the https://docs.killbill.io/latest/userguide_configuration.html[Kill Bill Configuration Guide].
-
 === Using Usage Rating APIs
 
 Full API documentation is available at https://apidocs.killbill.io/aviate-usage-rating[our API documentation].


### PR DESCRIPTION
Points 4 and 6

Update the relevant aviate docs to add a pre-requisite that the corresponding deployment should be added and point to the https://docs.killbill.io/latest/aviate-deployment-management doc. For example, before a catalog is created via aviate UI, we need the deployment added, so the [catalog doc](https://docs.killbill.io/latest/aviate-catalog-guide) needs to updated.

Update all aviate docs to remove the section that specifies a property needs to be set to enable the feature. For example the [tax doc](https://docs.killbill.io/latest/aviate-tax) specifies that the com.killbill.billing.plugin.aviate.enableTax=true property needs to be set. These are set to true by default now, so no need to do anything.